### PR TITLE
Fix duplicate mcp importer in package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "open-edison"
-version = "0.1.36"
+version = "0.1.37"
 description = "Open-source MCP security, aggregation, and monitoring. Single-user, self-hosted MCP proxy."
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ dev-dependencies = [
 allow-direct-references = true
 
 [tool.hatch.build.targets.wheel]
-packages = ["src", "src/mcp_importer"]
+packages = ["src"]
 include = [
   "README.md",
   "LICENSE",

--- a/uv.lock
+++ b/uv.lock
@@ -983,7 +983,7 @@ wheels = [
 
 [[package]]
 name = "open-edison"
-version = "0.1.36"
+version = "0.1.37"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Pypi complains when you double-include something in a wheel/sdist (bc they're zip files which support that lol)