### PR TITLE
[GENT-1171] Fix vscode export JSON

### DIFF
--- a/src/mcp_importer/exporters.py
+++ b/src/mcp_importer/exporters.py
@@ -300,7 +300,7 @@ def export_to_vscode(
 
     # Build the minimal config
     new_config: dict[str, Any] = {
-        "mcpServers": _build_open_edison_server(name=server_name, url=url, api_key=api_key)
+        "servers": _build_open_edison_server(name=server_name, url=url, api_key=api_key)
     }
 
     # If already configured exactly as desired and not forcing, no-op


### PR DESCRIPTION
See title, small change to make the export dump into `servers: ` instead of `mcpServers: ` which is what the vscode mcp standard asks for.