### PR TITLE
Improve initialize and reinitialize performance

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -382,7 +382,7 @@ class OpenEdisonProxy:
             log.warning(f"Failed to pre-initialize sessions database: {db_err}")
 
         # Initialize the FastMCP server (this handles starting enabled MCP servers)
-        await self.single_user_mcp.initialize()
+        await self.single_user_mcp.initialize(rewarm_caches=True)
 
         # Emit snapshot of enabled servers
         enabled_count = len([s for s in Config().mcp_servers if s.enabled])
@@ -627,7 +627,7 @@ class OpenEdisonProxy:
     async def unmount_mcp_server(self, server_name: str) -> dict[str, Any]:
         """Unmount a previously mounted MCP server by name (auth required)."""
         try:
-            ok = await self.single_user_mcp.unmount(server_name)
+            ok = await self.single_user_mcp.unmount(server_name, rewarm_caches=True)
             return {"unmounted": bool(ok), "server": server_name}
         except Exception as e:
             log.error(f"❌ Failed to unmount server {server_name}: {e}")

--- a/src/single_user_mcp.py
+++ b/src/single_user_mcp.py
@@ -5,6 +5,8 @@ FastMCP instance for the single-user Open Edison setup.
 Handles MCP protocol communication with running servers using a unified composite proxy.
 """
 
+import asyncio
+import time
 from typing import Any, TypedDict
 
 from fastmcp import Client as FastMCPClient
@@ -245,7 +247,7 @@ class SingleUserMCP(FastMCP[Any]):
             log.error(f"❌ Failed to mount server {server_name}: {e}")
             return False
 
-    async def unmount(self, server_name: str) -> bool:
+    async def unmount(self, server_name: str, rewarm_caches: bool = False) -> bool:
         """
         Unmount a previously mounted server by name.
 
@@ -277,9 +279,10 @@ class SingleUserMCP(FastMCP[Any]):
             mounted_list[:] = new_list
 
         # Invalidate and warm lists to ensure reload
-        _ = await self._tool_manager.list_tools()
-        _ = await self._resource_manager.list_resources()
-        _ = await self._prompt_manager.list_prompts()
+        if rewarm_caches:
+            _ = await self._tool_manager.list_tools()
+            _ = await self._resource_manager.list_resources()
+            _ = await self._prompt_manager.list_prompts()
 
         log.info(f"🧹 Unmounted server {server_name} and cleared references")
         return True
@@ -302,6 +305,40 @@ class SingleUserMCP(FastMCP[Any]):
         except Exception as e:
             log.warning(f"Error sending unmount notifications: {e}")
 
+    async def list_servers_components_parallel(self) -> None:
+        """Reload all servers' components in parallel."""
+
+        # Reload a server's components in parallel
+        async def list_server_components(server: Any) -> None:
+            log.debug(f"Reloading all components for server {server.prefix} in parallel...")
+            server_time = time.perf_counter()
+
+            # await server.server._list_tools()
+            # Run all three list operations in parallel
+            await asyncio.gather(
+                server.server._list_tools(),
+                server.server._list_resources(),
+                server.server._list_prompts(),
+                return_exceptions=True,
+            )
+            log.debug("Reloading complete")
+            log.debug(
+                f"Time taken to reload server {server.prefix}: {time.perf_counter() - server_time} seconds"
+            )
+
+        # Execute all server reloads in parallel
+        list_tasks = [
+            list_server_components(server)
+            for server in self._tool_manager._mounted_servers  # type: ignore
+        ]
+
+        log.debug(f"Starting reload for {len(list_tasks)} servers in parallel")
+        start_time = time.perf_counter()
+        if list_tasks:
+            await asyncio.gather(*list_tasks)
+        end_time = time.perf_counter()
+        log.debug(f"Time taken to reload all servers: {end_time - start_time} seconds")
+
     async def initialize(self, rewarm_caches: bool = False) -> None:
         """Initialize the FastMCP server using unified composite proxy approach.
 
@@ -319,7 +356,7 @@ class SingleUserMCP(FastMCP[Any]):
 
         # Unmount all servers
         for server_name in list(mounted_servers.keys()):
-            await self.unmount(server_name)
+            await self.unmount(server_name, rewarm_caches=False)
 
         # Create composite proxy for all real servers
         success = await self.create_composite_proxy(enabled_servers)
@@ -327,22 +364,10 @@ class SingleUserMCP(FastMCP[Any]):
             log.error("Failed to create composite proxy")
             return
 
-        log.info("✅ Single User MCP server initialized with composite proxy")
-
         if rewarm_caches:
-            # Invalidate and warm lists to ensure reload
-            log.debug("Reloading tool list...")
-            _ = await self._tool_manager.list_tools()
-            log.debug("Reloading resource list...")
-            _ = await self._resource_manager.list_resources()
-            log.debug("Reloading prompt list...")
-            _ = await self._prompt_manager.list_prompts()
-            log.debug("Reloading complete")
+            await self.list_servers_components_parallel()
 
-            # Send notifications to clients about changed component lists
-            log.debug("Sending list changed notifications...")
-            await self._send_list_changed_notifications()
-            log.debug("List changed notifications sent")
+        log.info("✅ Single User MCP server initialized with composite proxy")
 
     def _calculate_risk_level(self, trifecta: dict[str, bool]) -> str:
         """


### PR DESCRIPTION
-Load tools, resource and prompts in parallel for all servers
-Enable rewarm caches (list_tools) on first initialize to reduce lag when connecting a client to the server (tbd)
-Disable rewarm caches (list_tools) inside unmount when unmount is called via initialize and not the API