### PR TITLE
Open-edison and frontend fixes and improvements

### DIFF
--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -57,7 +57,20 @@ self.addEventListener('notificationclick', (event) => {
         }
 
         if (action === 'deny') {
-            // No-op; could notify page if desired
+            // Send deny request to backend
+            const body = {
+                session_id: data.sessionId,
+                kind: data.kind,
+                name: data.name,
+                command: 'deny'
+            };
+            event.waitUntil(
+                fetch('/api/approve_or_deny', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(body)
+                }).catch(() => { })
+            );
             return;
         }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "open-edison"
-version = "0.1.94"
+version = "0.1.95"
 description = "Open-source MCP security, aggregation, and monitoring. Single-user, self-hosted MCP proxy."
 readme = "README.md"
 authors = [

--- a/src/middleware/session_tracking.py
+++ b/src/middleware/session_tracking.py
@@ -402,15 +402,8 @@ class SessionTrackingMiddleware(Middleware):
             )
             if not approved:
                 # Return formatted SecurityError message (includes ASCII art)
-                return ToolResult(
-                    content=[
-                        {
-                            "type": "text",
-                            "text": str(e),
-                        }
-                    ],
-                    structured_content=None,
-                )
+                raise ToolError(str(e)) from e
+
             # Approved: apply effects and proceed
             session.data_access_tracker.apply_effects_after_manual_approval(
                 "tool", context.message.name
@@ -433,42 +426,6 @@ class SessionTrackingMiddleware(Middleware):
             _persist_session_to_db(session)
 
             return result
-        except NotFoundError as e:
-            new_tool_call.status = "error"
-            new_tool_call.duration_ms = (time.perf_counter() - start_time) * 1000.0
-
-            _persist_session_to_db(session)
-
-            # Return concise not-found message similar to ToolError handling
-            log.warning(f"Tool not found: {context.message.name}: {e}")
-            return ToolResult(
-                content=[
-                    {
-                        "type": "text",
-                        "text": (
-                            f"Tool '{context.message.name}' not found. Please check the tool name or mounted servers."
-                        ),
-                    }
-                ],
-                structured_content=None,
-            )
-        except ToolError as e:
-            new_tool_call.status = "error"
-            new_tool_call.duration_ms = (time.perf_counter() - start_time) * 1000.0
-
-            _persist_session_to_db(session)
-
-            # Convert tool errors to a concise ToolResult rather than bubbling a stack trace
-            log.warning(f"Tool failed: {context.message.name}: {e}")
-            return ToolResult(
-                content=[
-                    {
-                        "type": "text",
-                        "text": (f"Tool '{context.message.name}' failed: {str(e)}"),
-                    }
-                ],
-                structured_content=None,
-            )
         except Exception:
             new_tool_call.status = "error"
             new_tool_call.duration_ms = (time.perf_counter() - start_time) * 1000.0


### PR DESCRIPTION
    Open-Edison: Detect when a server's configuration has changed and remount it if necessary
    Frontend: Fix raw config change to config.json not clearing server cache
    Frontend: Align default imported permissions with default oe permissions
    Frontend: Fix raw config view's Update configuration remaining highlighted after page refresh
    Open-Edison: Deny tool call immediately, when the user click Deny.
    Open-Edison: Do not return ToolResult on tool fail, it breaks mcp with structured output validation error